### PR TITLE
Improve chess units handling

### DIFF
--- a/HChess.Tests/DrawTestUnit.cs
+++ b/HChess.Tests/DrawTestUnit.cs
@@ -18,7 +18,7 @@ namespace HBoard.Tests
     public class DrawTestUnit
     {
         [TestMethod]
-        public void TestMethod2()
+        public void TestKings()
         {
             var options = new GameOptions
             {
@@ -27,8 +27,8 @@ namespace HBoard.Tests
                     ChessPlayer white = (ChessPlayer) context.Players.First(),
                                 black = (ChessPlayer) context.Players.Last();
 
-                    board.AddUnit<KingUnit>(white, Point.Empty, new Point(4, 0));
-                    board.AddUnit<KingUnit>(black, Point.Empty, new Point(4, 0));
+                    board.AddUnit<KingUnit>(Orientation.Vertical, white, Point.Empty, new Point(0, 4));
+                    board.AddUnit<KingUnit>(Orientation.Vertical, black, Point.Empty, new Point(0, 4));
                 },
                 BoardSize = new Size(8, 8)
             };
@@ -40,12 +40,11 @@ namespace HBoard.Tests
             });
             gameContext.Init();
 
-            var enumerator = new IndexableEnumerator<BoardCell>(gameContext.Board.GetEnumerator(), gameContext.Board.Cells);
+            var enumerator = gameContext.Board.Cells.GetArrayEnumerator();
             while (enumerator.MoveNext())
             {
                 Debug.WriteLine(enumerator.Index + ": " + (enumerator.Current == null ? "null" : enumerator.Positions.JoinFormat(", ", "[{0}]", enumerator.Current)));
             }
-
 
             Assert.IsTrue(gameContext.IsDraw());
         }

--- a/HChess.Tests/GenerationTestUnit.cs
+++ b/HChess.Tests/GenerationTestUnit.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Drawing;
+using System.IO;
+using ExtensionLib;
+using HBoard.Core;
+using HBoard.Chess;
+using HBoard.Chess.Units;
+using HBoard.Chess.Generation;
+
+namespace HBoard.Tests
+{
+
+    [TestClass]
+    public class GenerationTestUnit
+    {
+        [TestMethod]
+        public void TestClassicBoard()
+        {
+            var options = new GameOptions
+            {
+                PopulateBoardDelegate = ClassicBoard.GenerateClassicBoard,
+                BoardSize = new Size(ClassicBoard.BOARD_WIDTH, ClassicBoard.BOARD_HEIGHT)
+            };
+
+            var gameContext = new GameContext(options, new[]
+            {
+                new ChessPlayer(PlayerType.White),
+                new ChessPlayer(PlayerType.Black)
+            });
+            gameContext.Init();
+            const String path = @"..\..\GeneratedBoards\ChessBoard.html";
+            try
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(path));
+                File.Create(path).Close();
+            }
+            catch { }
+            using (StreamWriter sw = new StreamWriter(path, false) { AutoFlush = true })
+            {
+                sw.Write(@"
+<head>
+<style type=""text/css"">
+	table {
+		border: 10px solid #665229;
+		}
+	td, th {
+		width: 100px;
+		height: 100px;
+		text-align: center;
+		border: 2px solid black;
+	}
+    .white {
+        background-color: #FFCC66;
+        color: black;
+    }
+    .black {
+        background-color: #665229;
+        color: black;
+    }
+</style>
+</head>
+<body>
+<table id=""chess_board"" cellpadding=""0"" cellspacing=""0"" style=""background-color: #FFDB94"">
+<caption style= ""font-size: 25"">HBoard Chess<caption>
+<tr style= ""width: 50px"">
+<th></th>
+<th>A</th>
+<th>B</th>
+<th>C</th>
+<th>D</th>
+<th>E</th>
+<th>F</th>
+<th>G</th>
+<th>H</th>
+</tr>");
+                var enumerator = gameContext.Board.Cells.GetArrayEnumerator();
+                int y = 0;
+
+                sw.WriteLine("</tr><tr><th>" + (gameContext.Board.Height - y) + "</th>");
+
+                while (enumerator.MoveNext())
+                {
+                    if (y != enumerator.Positions[0])
+                    {
+                        y = enumerator.Positions[0];
+                        sw.WriteLine("</tr><tr><th>" + (gameContext.Board.Height - y) +"</th>");
+                        sw.Flush();
+                    }
+                    var cell = (BoardCell) enumerator.Current;
+                    var player = cell == null || cell.Content == null
+                        ? null
+                        : (ChessPlayer) cell.Content.Player;
+                    sw.WriteLine(
+                        "<td style=\"" +
+                        (player == null
+                            ? null
+                            : "background-color: " + (player.Type == PlayerType.Black ? "#444" : "#ccc")) + "\">" +
+                        (enumerator.Current == null ? null : enumerator.Current.ToString()) + "</td>");
+                    sw.Flush();
+                }
+                sw.WriteLine("</table></body>");
+            }
+        }
+    }
+}

--- a/HChess.Tests/HBoard.Tests.csproj
+++ b/HChess.Tests/HBoard.Tests.csproj
@@ -55,8 +55,11 @@
   </Choose>
   <ItemGroup>
     <Compile Include="DrawTestUnit.cs" />
-    <Compile Include="TestUnits.cs" />
+    <Compile Include="GenerationTestUnit.cs" />
+    <Compile Include="Movement\QueenTestUnit.cs" />
+    <Compile Include="Movement\RookTestUnit.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Movement\BishopTestUnit.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\HChess\HBoard.csproj">

--- a/HChess.Tests/Movement/BishopTestUnit.cs
+++ b/HChess.Tests/Movement/BishopTestUnit.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Drawing;
+using System.Linq;
+using System.IO;
+using ExtensionLib;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using HBoard.Core;
+using HBoard.Chess;
+using HBoard.Chess.Generation;
+using HBoard.Chess.Units;
+using HBoard.Logic;
+
+namespace HChess.Tests.Movement
+{
+    [TestClass]
+    public class BishopTestUnit
+    {
+        [TestMethod]
+        public void TestClassicDefault()
+        {
+            var options = new GameOptions
+            {
+                PopulateBoardDelegate = ClassicBoard.GenerateClassicBoard,
+                BoardSize = new Size(ClassicBoard.BOARD_WIDTH, ClassicBoard.BOARD_HEIGHT)
+            };
+
+            var gameContext = new GameContext(options, new[]
+            {
+                new ChessPlayer(PlayerType.White),
+                new ChessPlayer(PlayerType.Black)
+            });
+            gameContext.Init();
+
+            var bishop = gameContext.Board
+                .Select((x, i) => new { Index = i, Cell = x == null ? null : x.Content as BishopUnit})
+                .Where(x => x.Cell != null)
+                .First();
+
+            var path = bishop.Cell.GetMovementPaths(gameContext.Board, new Point(bishop.Index / 8, bishop.Index % 8)).First();
+
+            Assert.AreEqual(0, path.First().Length);
+            Assert.AreEqual(0, path.Last().Length);
+        }
+
+        [TestMethod]
+        public void TestLastAxisIntersectOrigin()
+        {
+            var options = new GameOptions
+            {
+                PopulateBoardDelegate = delegate(GameContext context, GameBoard board)
+                {
+                    ChessPlayer white = (ChessPlayer) context.Players.First(),
+                                black = (ChessPlayer) context.Players.Last();
+
+                    board.AddUnit<BishopUnit>(Orientation.Vertical, white, Point.Empty, new Point(3, 4));
+                    board.AddUnit<RookUnit>(Orientation.Vertical, white, Point.Empty, new Point(1, 2));
+                    board.AddUnit<PawnUnit>(Orientation.Vertical, black, Point.Empty, new Point(5, 1));
+                },
+                BoardSize = new Size(8, 8)
+            };
+
+            var gameContext = new GameContext(options, new[]
+            {
+                new ChessPlayer(PlayerType.White),
+                new ChessPlayer(PlayerType.Black)
+            });
+            gameContext.Init();
+
+            var bishop = gameContext.Board
+                .Select((x, i) => new { Index = i, Cell = x == null ? null : x.Content as BishopUnit })
+                .Where(x => x.Cell != null)
+                .First();
+
+            var paths = bishop.Cell.GetMovementPaths(gameContext.Board, new Point(bishop.Index / 8, bishop.Index % 8));
+            MovementPath primePath = paths.First(), lastPath = paths.Last();
+
+            // Prime axis
+            Assert.AreEqual(primePath.First().Direction, Direction.Diagonal);
+            Assert.AreEqual(3, primePath.First().Length);
+            Assert.AreEqual(new Point(2, 3), primePath.Location);
+
+            // Last axis
+            Assert.AreEqual(lastPath.First().Direction, Direction.Diagonal);
+            Assert.AreEqual(7, lastPath.First().Length);
+            Assert.AreEqual(new Point(0, 7), lastPath.Location);
+        }
+    }
+}

--- a/HChess.Tests/Movement/QueenTestUnit.cs
+++ b/HChess.Tests/Movement/QueenTestUnit.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Drawing;
+using System.Linq;
+using System.IO;
+using ExtensionLib;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using HBoard.Core;
+using HBoard.Chess;
+using HBoard.Chess.Generation;
+using HBoard.Chess.Units;
+using HBoard.Logic;
+
+namespace HChess.Tests.Movement
+{
+    [TestClass]
+    public class QueenTestUnit
+    {
+        [TestMethod]
+        public void TestClassicDefault()
+        {
+            var options = new GameOptions
+            {
+                PopulateBoardDelegate = ClassicBoard.GenerateClassicBoard,
+                BoardSize = new Size(ClassicBoard.BOARD_WIDTH, ClassicBoard.BOARD_HEIGHT)
+            };
+
+            var gameContext = new GameContext(options, new[]
+            {
+                new ChessPlayer(PlayerType.White),
+                new ChessPlayer(PlayerType.Black)
+            });
+            gameContext.Init();
+
+            var queen = gameContext.Board
+                .Select((x, i) => new { Index = i, Cell = x == null ? null : x.Content as QueenUnit })
+                .Where(x => x.Cell != null)
+                .First();
+
+            var path = queen.Cell.GetMovementPaths(gameContext.Board, new Point(queen.Index / 8, queen.Index % 8)).First();
+
+            Assert.AreEqual(0, path.First().Length);
+            Assert.AreEqual(0, path.Last().Length);
+        }
+
+        [TestMethod]
+        public void TestLastAxisIntersectOrigin()
+        {
+            var options = new GameOptions
+            {
+                PopulateBoardDelegate = delegate(GameContext context, GameBoard board)
+                {
+                    ChessPlayer white = (ChessPlayer) context.Players.First(),
+                                black = (ChessPlayer) context.Players.Last();
+
+                    board.AddUnit<RookUnit>(Orientation.Vertical, white, Point.Empty, new Point(3, 4));
+                    board.AddUnit<BishopUnit>(Orientation.Vertical, white, Point.Empty, new Point(1, 4));
+                    board.AddUnit<PawnUnit>(Orientation.Vertical, black, Point.Empty, new Point(3, 1));
+                    board.AddUnit<QueenUnit>(Orientation.Vertical, white, Point.Empty, new Point(1, 6));
+                },
+                BoardSize = new Size(8, 8)
+            };
+
+            var gameContext = new GameContext(options, new[]
+            {
+                new ChessPlayer(PlayerType.White),
+                new ChessPlayer(PlayerType.Black)
+            });
+            gameContext.Init();
+
+            var queen = gameContext.Board
+                .Select((x, i) => new { Index = i, Cell = x == null ? null : x.Content as QueenUnit })
+                .Where(x => x.Cell != null)
+                .First();
+
+            var paths = queen.Cell.GetMovementPaths(gameContext.Board, new Point(queen.Index / 8, queen.Index % 8)).ToArray();
+            MovementPath primePath = paths[0], lastPath = paths[1],
+                         horizontalPath = paths[2], verticalPath = paths[3];
+
+            // Prime axis
+            Assert.AreEqual(primePath.First().Direction, Direction.Diagonal);
+            Assert.AreEqual(2, primePath.First().Length);
+            Assert.AreEqual(new Point(0, 5), primePath.Location);
+
+            // Last axis
+            Assert.AreEqual(lastPath.First().Direction, Direction.Diagonal);
+            Assert.AreEqual(2, lastPath.First().Length);
+            Assert.AreEqual(new Point(0, 7), lastPath.Location);
+
+            // Horizontal axis
+            Assert.AreEqual(horizontalPath.First().Direction, Direction.Horizontal);
+            Assert.AreEqual(2, horizontalPath.First().Length);
+            Assert.AreEqual(new Point(1, 5), horizontalPath.Location);
+
+            // Vertical axis
+            Assert.AreEqual(verticalPath.First().Direction, Direction.Vertical);
+            Assert.AreEqual(3, verticalPath.First().Length);
+            Assert.AreEqual(new Point(0, 6), verticalPath.Location);
+        }
+    }
+}

--- a/HChess.Tests/Movement/RookTestUnit.cs
+++ b/HChess.Tests/Movement/RookTestUnit.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Drawing;
+using System.Linq;
+using System.IO;
+using ExtensionLib;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using HBoard.Core;
+using HBoard.Chess;
+using HBoard.Chess.Generation;
+using HBoard.Chess.Units;
+using HBoard.Logic;
+
+namespace HChess.Tests.Movement
+{
+    [TestClass]
+    public class RookTestUnit
+    {
+        [TestMethod]
+        public void TestClassicDefault()
+        {
+            var options = new GameOptions
+            {
+                PopulateBoardDelegate = ClassicBoard.GenerateClassicBoard,
+                BoardSize = new Size(ClassicBoard.BOARD_WIDTH, ClassicBoard.BOARD_HEIGHT)
+            };
+
+            var gameContext = new GameContext(options, new[]
+            {
+                new ChessPlayer(PlayerType.White),
+                new ChessPlayer(PlayerType.Black)
+            });
+            gameContext.Init();
+
+            var rook = gameContext.Board
+                .Select((x, i) => new { Index = i, Cell = x == null ? null : x.Content as RookUnit })
+                .Where(x => x.Cell != null)
+                .First();
+
+            var path = rook.Cell.GetMovementPaths(gameContext.Board, new Point(rook.Index / 8, rook.Index % 8)).First();
+
+            Assert.AreEqual(0, path.First().Length);
+            Assert.AreEqual(0, path.Last().Length);
+        }
+
+        [TestMethod]
+        public void TestAxes()
+        {
+            var options = new GameOptions
+            {
+                PopulateBoardDelegate = delegate(GameContext context, GameBoard board)
+                {
+                    ChessPlayer white = (ChessPlayer) context.Players.First(),
+                                black = (ChessPlayer) context.Players.Last();
+
+                    board.AddUnit<RookUnit>(Orientation.Horizontal, white, Point.Empty, new Point(3, 4));
+                    board.AddUnit<BishopUnit>(Orientation.Horizontal, white, Point.Empty, new Point(2, 4));
+                    board.AddUnit<PawnUnit>(Orientation.Horizontal, black, Point.Empty, new Point(4, 6));
+                },
+                BoardSize = new Size(8, 8)
+            };
+
+            var gameContext = new GameContext(options, new[]
+            {
+                new ChessPlayer(PlayerType.White),
+                new ChessPlayer(PlayerType.Black)
+            });
+            gameContext.Init();
+
+            var rook = gameContext.Board
+                .Select((x, i) => new { Index = i, Cell = x == null ? null : x.Content as RookUnit })
+                .Where(x => x.Cell != null)
+                .First();
+
+            var paths = rook.Cell.GetMovementPaths(gameContext.Board, new Point(rook.Index / 8, rook.Index % 8));
+            MovementPath horizontalPath = paths.First(), verticalPath = paths.Last();
+
+            // Horizontal axis
+            Assert.AreEqual(horizontalPath.First().Direction, Direction.Horizontal);
+            Assert.AreEqual(6, horizontalPath.First().Length);
+            Assert.AreEqual(new Point(3, 0), horizontalPath.Location);
+
+            // Vertical axis
+            Assert.AreEqual(verticalPath.First().Direction, Direction.Vertical);
+            Assert.AreEqual(4, verticalPath.First().Length);
+            Assert.AreEqual(new Point(4, 4), verticalPath.Location);
+        }
+    }
+}

--- a/HChess/Chess/Generation/ClassicBoard.cs
+++ b/HChess/Chess/Generation/ClassicBoard.cs
@@ -19,23 +19,23 @@ namespace HBoard.Chess.Generation
         public static readonly Point[] RookPositions = new[]
         {
              new Point(0, 0),
-             new Point(7, 0)
+             new Point(0, 7)
         };
 
         private static readonly Point[] KnightPositions = new[]
         {
-            new Point(1, 0),
-            new Point(6, 0)
+            new Point(0, 1),
+            new Point(0, 6)
         };
 
         private static readonly Point[] BishopPositions = new[]
         {
-            new Point(2, 0),
-            new Point(5, 0)
+            new Point(0, 2),
+            new Point(0, 5)
         };
 
-        private static readonly Point QueenPosition = new Point(3, 0);
-        private static readonly Point KingPosition = new Point(4, 0);
+        private static readonly Point QueenPosition = new Point(0, 4);
+        private static readonly Point KingPosition = new Point(0, 3);
         #endregion
 
         public static void GenerateClassicBoard(GameContext context, GameBoard board)
@@ -46,31 +46,31 @@ namespace HBoard.Chess.Generation
             ChessPlayer white = (ChessPlayer) context.Players.First(),
                         black = (ChessPlayer) context.Players.Last();
 
-            for (int i = 0; i < board.Width; i++)
+            for (int i = 0; i < board.Height; i++)
             {
-                board[i, 1].Content = new PawnUnit(white);
-                board[i, board.Height - 2].Content = new PawnUnit(black);
+                board[1, i].Content = new PawnUnit(white);
+                board[board.Width - 2, i].Content = new PawnUnit(black);
             }
 
             int cycles = board.Width / BOARD_WIDTH;
             for (int i = 0; i <= cycles; i++)
             {
-                Point offset = new Point(i * BOARD_WIDTH, 0);
+                Point offset = new Point(0, i * BOARD_HEIGHT);
 
-                board.AddUnit<RookUnit>(white, offset, ClassicBoard.RookPositions);
-                board.AddUnit<RookUnit>(black, offset, ClassicBoard.RookPositions);
+                board.AddUnit<RookUnit>(Orientation.Horizontal, white, offset, ClassicBoard.RookPositions);
+                board.AddUnit<RookUnit>(Orientation.Horizontal, black, offset, ClassicBoard.RookPositions);
 
-                board.AddUnit<KnightUnit>(white, offset, ClassicBoard.KnightPositions);
-                board.AddUnit<KnightUnit>(black, offset, ClassicBoard.KnightPositions);
+                board.AddUnit<KnightUnit>(Orientation.Horizontal, white, offset, ClassicBoard.KnightPositions);
+                board.AddUnit<KnightUnit>(Orientation.Horizontal, black, offset, ClassicBoard.KnightPositions);
 
-                board.AddUnit<BishopUnit>(white, offset, ClassicBoard.BishopPositions);
-                board.AddUnit<BishopUnit>(black, offset, ClassicBoard.BishopPositions);
+                board.AddUnit<BishopUnit>(Orientation.Horizontal, white, offset, ClassicBoard.BishopPositions);
+                board.AddUnit<BishopUnit>(Orientation.Horizontal, black, offset, ClassicBoard.BishopPositions);
 
-                board.AddUnit<QueenUnit>(white, offset, ClassicBoard.QueenPosition);
-                board.AddUnit<QueenUnit>(black, offset, ClassicBoard.QueenPosition);
+                board.AddUnit<QueenUnit>(Orientation.Horizontal, white, offset, ClassicBoard.QueenPosition);
+                board.AddUnit<QueenUnit>(Orientation.Horizontal, black, offset, ClassicBoard.QueenPosition);
 
-                board.AddUnit<KingUnit>(white, offset, ClassicBoard.KingPosition);
-                board.AddUnit<KingUnit>(black, offset, ClassicBoard.KingPosition);              
+                board.AddUnit<KingUnit>(Orientation.Horizontal, white, offset, ClassicBoard.KingPosition);
+                board.AddUnit<KingUnit>(Orientation.Horizontal, black, offset, ClassicBoard.KingPosition);              
             }
         }
     }

--- a/HChess/Chess/Generation/GenerationHelper.cs
+++ b/HChess/Chess/Generation/GenerationHelper.cs
@@ -10,12 +10,23 @@ namespace HBoard.Chess.Generation
 {
     public static class GenerationHelper
     {
-        public static void AddUnit<T>(this GameBoard board, ChessPlayer player, params Point[] relativePositions) where T : BoardUnit, new()
+        public static void AddUnit<T>(this GameBoard board, Orientation orientation, ChessPlayer player, params Point[] relativePositions) where T : BoardUnit, new()
         {
-            AddUnit<T>(board, player, Point.Empty, relativePositions);
+            if (orientation == Orientation.Horizontal)
+                AddUnitHorizontally<T>(board, player, Point.Empty, relativePositions);
+            else
+                AddUnitVertically<T>(board, player, Point.Empty, relativePositions);
         }
 
-        public static void AddUnit<T>(this GameBoard board, ChessPlayer player, Point offset, params Point[] relativePositions) where T : BoardUnit, new()
+        public static void AddUnit<T>(this GameBoard board, Orientation orientation, ChessPlayer player, Point offset, params Point[] relativePositions) where T : BoardUnit, new()
+        {
+            if (orientation == Orientation.Horizontal)
+                AddUnitHorizontally<T>(board, player, offset, relativePositions);
+            else
+                AddUnitVertically<T>(board, player, offset, relativePositions);
+        }
+
+        private static void AddUnitVertically<T>(this GameBoard board, ChessPlayer player, Point offset, params Point[] relativePositions) where T : BoardUnit, new()
         {
             if (board == null)
                 throw new ArgumentNullException("board");
@@ -27,6 +38,21 @@ namespace HBoard.Chess.Generation
                     return;
 
                 board[offset.X + point.X, offset.Y + y].Content = new T { Player = player };
+            }
+        }
+
+        private static void AddUnitHorizontally<T>(this GameBoard board, ChessPlayer player, Point offset, params Point[] relativePositions) where T : BoardUnit, new()
+        {
+            if (board == null)
+                throw new ArgumentNullException("board");
+
+            foreach (Point point in relativePositions)
+            {
+                int x = player.Type == PlayerType.White ? point.X : board.Width - point.X - 1;
+                if (offset.Y + point.Y > board.Height - 1 || offset.X + point.X > board.Width - 1)
+                    return;
+
+                board[offset.X + x, offset.Y + point.Y].Content = new T { Player = player };
             }
         }
     }

--- a/HChess/Chess/Generation/Orientation.cs
+++ b/HChess/Chess/Generation/Orientation.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HBoard.Chess.Generation
+{
+    public enum Orientation
+    {
+        Horizontal,
+        Vertical
+    }
+}

--- a/HChess/Chess/Units/AxisHelper.cs
+++ b/HChess/Chess/Units/AxisHelper.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using HBoard.Chess.Logic;
+using HBoard.Core;
+using HBoard.Logic;
+
+namespace HBoard.Chess.Units
+{
+    public static class AxisHelper
+    {
+        public static Boolean AdvancePosition(this ChessUnit unit, IPlayer player, Point currentPosition, ref Int32 metric, ref Point position, Boolean hasCrossedOrigin)
+        {
+            if (player == null)
+            {
+                if (metric++ == 0)
+                    position = currentPosition;
+            }
+            else if (!hasCrossedOrigin)
+            {
+                position = currentPosition;
+                metric = player == unit.Player ? 0 : 1;
+            }
+            else
+            {
+                if (player != unit.Player)
+                    metric++;
+                return true;
+            }
+
+            return false;
+        }
+
+        public static MovementPath GetPath(Point position, Int64 metric, Direction direction, MovementType movement = MovementType.All)
+        {
+            return new MovementPath(
+                location: position,
+                vectors: new SpecializedMovementVector(
+                    direction: direction,
+                    metric: metric,
+                    movement: movement));
+        }
+    }
+}

--- a/HChess/Chess/Units/RookUnit.cs
+++ b/HChess/Chess/Units/RookUnit.cs
@@ -4,8 +4,10 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Drawing;
+using ExtensionLib;
 using HBoard.Core;
 using HBoard.Logic;
+using HBoard.Chess.Logic;
 
 namespace HBoard.Chess.Units
 {
@@ -34,7 +36,40 @@ namespace HBoard.Chess.Units
 
         public override IEnumerable<MovementPath> GetMovementPaths(GameBoard board, Point position)
         {
-            throw new NotImplementedException();
+            Point horizontalLocation = Point.Empty;
+            Point verticalLocation = Point.Empty;
+
+            int horizontalMetric = 0;
+            int verticalMetric = 0;
+            bool hasCrossedOrigin = false;
+            bool horizontalAxisResolved = false;
+            bool verticalAxisResolved = false;
+
+            var enumerator = board.Cells.GetArrayEnumerator();
+            while (enumerator.MoveNext())
+            {
+                BoardCell cell = (BoardCell) enumerator.Current;
+                Point currentPosition = new Point(enumerator.Positions[0], enumerator.Positions[1]);
+
+                var cellContent = cell == null ? null : cell.Content;
+                var cellPlayer = cellContent == null ? null : cell.Content.Player;
+
+                bool isOnVerticalAxis = currentPosition.Y == position.Y,
+                     isOnHorizontalAxis = currentPosition.X == position.X;
+
+                if (isOnHorizontalAxis && isOnVerticalAxis)
+                    hasCrossedOrigin = true;
+                else if (isOnVerticalAxis && !verticalAxisResolved)
+                    verticalAxisResolved = this.AdvancePosition(cellPlayer, currentPosition, ref verticalMetric, ref verticalLocation, hasCrossedOrigin);
+                else if (isOnHorizontalAxis && !horizontalAxisResolved)
+                    horizontalAxisResolved = this.AdvancePosition(cellPlayer, currentPosition, ref horizontalMetric, ref horizontalLocation, hasCrossedOrigin);
+            }
+
+            return new[]
+            {
+                AxisHelper.GetPath(horizontalLocation, horizontalMetric, Direction.Horizontal),
+                AxisHelper.GetPath(verticalLocation, verticalMetric, Direction.Vertical)
+            };
         }
     }
 }

--- a/HChess/HBoard.csproj
+++ b/HChess/HBoard.csproj
@@ -30,6 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="ExtensionLib">
+      <HintPath>..\Libraries\ExtensionLib.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
@@ -48,12 +51,13 @@
     <Compile Include="Chess\Generation\BoardGenerationException.cs" />
     <Compile Include="Chess\Generation\ClassicBoard.cs" />
     <Compile Include="Chess\Generation\GenerationHelper.cs" />
+    <Compile Include="Chess\Generation\Orientation.cs" />
     <Compile Include="Chess\Logic\MovementType.cs" />
     <Compile Include="Chess\Logic\SpecializedMovementVector.cs" />
     <Compile Include="Chess\PawnExtension.cs" />
     <Compile Include="Chess\PlayerType.cs" />
+    <Compile Include="Chess\Units\AxisHelper.cs" />
     <Compile Include="Chess\Units\ChessUnit.cs" />
-    <Compile Include="Logic\ArrayEnumerator.cs" />
     <Compile Include="Logic\Direction.cs" />
     <Compile Include="Logic\IVector.cs" />
     <Compile Include="Logic\MovementPath.cs" />


### PR DESCRIPTION
Here's a fully-implemented version of the previous chess unit handling logic.

I've also migrated the board generation to a new test unit for the meantime, although, it would be preferable to migrate it to a fully-fledged _fixture_-based test system.
