### PR TITLE
Improve diagonal direction handling

### DIFF
--- a/HBoard.Tests/Movement/BishopTestUnit.cs
+++ b/HBoard.Tests/Movement/BishopTestUnit.cs
@@ -70,12 +70,12 @@ namespace HBoard.Tests.Movement
             MovementPath primePath = paths.First(), lastPath = paths.Last();
 
             // Prime axis
-            Assert.AreEqual(primePath.First().Direction, Direction.Diagonal);
+            Assert.AreEqual(primePath.First().Direction, Direction.PrimeDiagonal);
             Assert.AreEqual(3, primePath.First().Length);
             Assert.AreEqual(new Point(2, 3), primePath.Location);
 
             // Last axis
-            Assert.AreEqual(lastPath.First().Direction, Direction.Diagonal);
+            Assert.AreEqual(lastPath.First().Direction, Direction.LastDiagonal);
             Assert.AreEqual(7, lastPath.First().Length);
             Assert.AreEqual(new Point(0, 7), lastPath.Location);
         }

--- a/HBoard.Tests/Movement/QueenTestUnit.cs
+++ b/HBoard.Tests/Movement/QueenTestUnit.cs
@@ -72,12 +72,12 @@ namespace HBoard.Tests.Movement
                          horizontalPath = paths[2], verticalPath = paths[3];
 
             // Prime axis
-            Assert.AreEqual(primePath.First().Direction, Direction.Diagonal);
+            Assert.AreEqual(primePath.First().Direction, Direction.PrimeDiagonal);
             Assert.AreEqual(2, primePath.First().Length);
             Assert.AreEqual(new Point(0, 5), primePath.Location);
 
             // Last axis
-            Assert.AreEqual(lastPath.First().Direction, Direction.Diagonal);
+            Assert.AreEqual(lastPath.First().Direction, Direction.LastDiagonal);
             Assert.AreEqual(2, lastPath.First().Length);
             Assert.AreEqual(new Point(0, 7), lastPath.Location);
 

--- a/HBoard/Chess/ChessLogic.cs
+++ b/HBoard/Chess/ChessLogic.cs
@@ -13,7 +13,7 @@ namespace HBoard.Chess
         {
             if (game == null)
                 throw new ArgumentNullException("game");
-            
+
             var players = game.Players.ToArray();
             if (players.Count(x => !x.Eliminated) == 1)
                 return players.Single();
@@ -54,7 +54,7 @@ namespace HBoard.Chess
 
             while (enumerator.MoveNext())
             {
-                var unit = ((BoardCell)enumerator.Current).Content as ChessUnit;
+                var unit = ((BoardCell) enumerator.Current).Content as ChessUnit;
 
                 if (unit != null)
                     unit.GenerateCache(game.Board, new Point(enumerator.Positions[0], enumerator.Positions[1]));

--- a/HBoard/Chess/Units/BishopUnit.cs
+++ b/HBoard/Chess/Units/BishopUnit.cs
@@ -68,8 +68,8 @@ namespace HBoard.Chess.Units
 
             return new[]
             {
-                AxisHelper.GetPath(primeLocation, primeMetric, Direction.Diagonal),
-                AxisHelper.GetPath(lastLocation, lastMetric, Direction.Diagonal)
+                AxisHelper.GetPath(primeLocation, primeMetric, Direction.PrimeDiagonal),
+                AxisHelper.GetPath(lastLocation, lastMetric, Direction.LastDiagonal)
             };
         }
     }

--- a/HBoard/Chess/Units/QueenUnit.cs
+++ b/HBoard/Chess/Units/QueenUnit.cs
@@ -75,8 +75,8 @@ namespace HBoard.Chess.Units
 
             return new[]
             {
-                AxisHelper.GetPath(primePosition, primeMetric, Direction.Diagonal),
-                AxisHelper.GetPath(lastPosition, lastMetric, Direction.Diagonal),
+                AxisHelper.GetPath(primePosition, primeMetric, Direction.PrimeDiagonal),
+                AxisHelper.GetPath(lastPosition, lastMetric, Direction.LastDiagonal),
                 AxisHelper.GetPath(horizontalPosition, horizontalMetric, Direction.Horizontal),
                 AxisHelper.GetPath(verticalPosition, verticalMetric, Direction.Vertical)
             };

--- a/HBoard/Logic/Direction.cs
+++ b/HBoard/Logic/Direction.cs
@@ -4,6 +4,7 @@
     {
         Horizontal,
         Vertical,
-        Diagonal,
+        PrimeDiagonal,
+        LastDiagonal
     }
 }


### PR DESCRIPTION
Instead of dealing with unidirectional and _undefined_ diagonal directions, we should have an explicit direction semantics: I suggest including `Direction.PrimeDiagonal` and `Direction.LastDiagonal`.

Perhaps we should also include a way to obtain the location at the other end of the axis, within the `MovementPath` class?
